### PR TITLE
Updated jackson-databind to address vulnerability

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,7 +17,7 @@ libraryDependencies ++= Seq(
   "org.scalatest" %% "scalatest" % "3.1.1" % Test
 )
 
-dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.3"
+dependencyOverrides += "com.fasterxml.jackson.core" % "jackson-databind" % "2.10.5.1"
 
 credentials += Credentials(Path.userHome / ".mdialog.credentials")
 


### PR DESCRIPTION
Introduced through: com.fasterxml.jackson.core:jackson-databind@2.10.3 and org.json4s:json4s-jackson_2.13@3.6.7
Fixed in: com.fasterxml.jackson.core:jackson-databind@2.6.7.4, @2.9.10.7, @2.10.5.1

Introduced through: project@1.0.0-SNAPSHOT › com.fasterxml.jackson.core:jackson-databind@2.10.3
Remediation: Upgrade to com.fasterxml.jackson.core:jackson-databind@2.10.5.1
Introduced through: project@1.0.0-SNAPSHOT › org.json4s:json4s-jackson_2.13@3.6.7 › com.fasterxml.jackson.core:jackson-databind@2.10.3
Vulnerable Functions
com/fasterxml/jackson/databind/ext/DOMSerializer.<init>
  
Overview
com.fasterxml.jackson.core:jackson-databind is a library which contains the general-purpose data-binding functionality and tree-model for Jackson Data Processor.

Affected versions of this package are vulnerable to XML External Entity (XXE) Injection. A flaw was found in FasterXML Jackson Databind, where it does not have entity expansion secured properly in the DOMDeserializer class. The highest threat from this vulnerability is data integrity.